### PR TITLE
check for file existing at URL not server path

### DIFF
--- a/lib/ImageHelper.php
+++ b/lib/ImageHelper.php
@@ -345,7 +345,7 @@ class ImageHelper {
 	 */
 	public static function get_sideloaded_file_loc( $file ) {
 		$upload = wp_upload_dir();
-		$dir = $upload['path'];
+		$dir = $upload['url'];
 		$filename = $file;
 		$file = parse_url($file);
 		$path_parts = pathinfo($file['path']);


### PR DESCRIPTION
The get_sideloaded_file_loc function currently checks the server path for the existence of the file and in a lot of contexts the image will be generated again if it is not found there. Checking for the file URL existing instead will increase compatibility with a lot of CDN situations including WPEngine's LargeFS system, and I assume would also make things work better with the [WP Offload Media](https://deliciousbrains.com/wp-offload-media/) plugin.

## Issue
<!-- Description of the problem that this code change is solving -->
Images are regenerated over and over if they are offloaded to a CDN and not permanently stored on the original local server location.

## Solution
<!-- Description of the solution that this code changes are introducing to the application. -->
Check for the URL instead of the server path.

## Impact
Should maintain compatibility for existing users who store their images on the local server, but should now also support various CDN and object storage situations.

## Usage Changes
Should not effect usage at all.


## Testing
Should work with existing unit tests
Would be worth doing some additional manual testing in various server environments... 
